### PR TITLE
SauceLabs testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,30 +2,33 @@ language: node_js
 sudo: required
 env:
   global:
-    - CC_TEST_REPORTER_ID=0633d054e8bc3a1dfdc6b4fd8755540553f093491e5eabbd9caedb1966fefbdb
+  - CC_TEST_REPORTER_ID=0633d054e8bc3a1dfdc6b4fd8755540553f093491e5eabbd9caedb1966fefbdb
+  - secure: nh1pJOcOLpMHFq3idT2dkhhGzNH7W77l6GNrqKCWW1PfVVZJ5uZV5S5d0/Qlbn8dxCriXyXumx7enli7Z5GsJ6YnkAqRc/OwmWR5pzndAkMw2eKPbrHGeG7+af8rXDAbTu9U9B19iYsFNkYV5y5qi4VgG7FKBoQpZgzrzOmlingGcNmGLs0ZSGy6joasnD6yWoyk6TZ9Qzr63rF284n9VDGRGeqVHvAi5eUZHtCAQwbWhuX6d2t+WF3vmUZGDEdviL3f8T3t+C5zPNcE6eBx7zfO6CCoysSXH9ZtREBeDkSDdd+C5Qnv35tWK82WEKeDGKgHuYZpFB6XKdC/JmzISpB25Zu/zIPR4KENEdYI1xR1DcuRng/XmP8PAHNHy6M7aB0qTE4wKM4VVcNgHSAcNXdu04PRAkCD6oDydQXaJeIiyJUoSKANdPGwWvJWQYhfuIcfN0tU0lcGVI86l2gALo9ZIk08Dr+Jh+fZfg5aH1eLvM8LyOmHaCWwn+fcJgrRbOTG3pxS3/2l6BKoaYtz/EA0k8i/U2WTHn8udvMbJ1zzVzlXgcNwuqMc5z6VNRDpj4dxFrkwqJ+mPxSz4ppLM0TzWseevJCCf0DUFwQk7jSkaRbW6K7sgmygaqrp4ZQjkTnB62aThxEu7VsHgMCt4aa7ML2hU4nizm+IiEw2CTc=
+  - secure: OmuivyYIJuljWeAUrKgFsvwh3OnsVS9mTrlaARjN7uqp/JlqrrpcQLLhQVYHLgKpR1dzQnBr/jIzJSp8L+jL8xe1YWvFLdBeZc634hznVQwYQESqcrmSwQHRYQaHe0HolmPNaYJ5KC21PNGUFWhYY4aRvVaqBUArTpz6v+mD4olTBaf+795EcO7591E3xKHKXe+mIKGVGDKEv8t03W8i0F8Pd/skjAOinWpbm08ONfF8LMi3Yp0wx2gIjpVPP1cRQeXrJUFDnR3vX7VICL9kIgIEnsmDr7xs93usvO/8Xnw8puZSInObl7c7ErFnOk/4lrmxBR/Fv18BHOFjJZIynWN5nWJ8yGsmA0Yu1Asb6mAwUbv/4qwuKG7Weab4xYZDktvVcT46kgyoMTVLmHxDivOeIVKiA+BRd7ukbdzTNKYZfjLM3COEtpYJ5aqB/fUZlH8yHKzkAOeirrgyVwYeENOcdn4jrsjaXgJGbB8D94yngcXN+Bf+P0e99I5vLrz/JHReEqhFtyZFza9K3CrdlA/VJ0zN1CFb/Z7/sFuwH/2H+/DIWcdL/J6KYUmhtfX43J72JxJ3cwSHjv0TkgH20r2oVr+wtag+lwqSPSahZam+icem6DMw9SgHg38r03tY47+orHxjwl6ckCE2HuZKv+MICRlZsjD3qc3tuDlnTDs=
 addons:
   firefox: latest
   apt:
     sources:
-      - google-chrome
+    - google-chrome
     packages:
-      - google-chrome-stable
+    - google-chrome-stable
 cache:
   yarn: true
   directories:
-    - node_modules
-    - bower_components
-    - ".eslintcache"
-    - "$HOME/.cache/bower"
+  - node_modules
+  - bower_components
+  - ".eslintcache"
+  - "$HOME/.cache/bower"
 before_script:
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
-  - yarn run lint
+- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
+  > ./cc-test-reporter
+- chmod +x ./cc-test-reporter
+- "./cc-test-reporter before-build"
+- yarn run lint
 script:
-  - xvfb-run yarn test
+- xvfb-run yarn test
 after_script:
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+- "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"
 notifications:
   slack:
     secure: lskikigS+9djhBsz/gps5F9mRV7nHhRurN44aSb5LzKZTmiWqchZE2XpcpOpJHkGcO/e5Yl1tWVhD8P6Qif1RweW0sgwMH7TvcJazvbncTVSIojbXDw4vmPut+IMAVe2IwhfrY8FvksRlAAsL7wsGY4QTCL9XGfXy72UHL/53Pzfyf9XMkKkCIMRASUXXu6M6iF0yBcZhQCAb3NmccwRrH3sjwE29fn4f4P5IeP/7LHM3MJHEDZsOGzY7dqOocfahuXK1R1M00IwgEu5jvgUzjm+wRRnG47sdWlGw6mDLT0h0eDi3q5Zoy3WxnVFAqjfJtB+P17QiMP39yDkjIe9gR1ph0x46lKppKN2QhGFUX31K253V21esrHlDf1+V+bZFATinvh2XJBpIlTR8C4f9MW2tAzAw8NEQGWBKaS11LGNa12We9RT8kLGFSqWtsEkOoykiYnII1/Ayt//o1OJwbKM+7/Ps9ugOBSl6kdJpflx1D4hNwZOBCM8+VIuVw4SPthy+x8MTycAIDpHFhOa+3QsnaI1V86JcJPJ1MXF58abtXkgRqfOBpcn+7/i54K55u3uGu678qcHL2oN8s/QNA4KKeN1VjIWrhsfZQXq1ERhm7i0d7phOP2fgvYEZCKqVGmXv/dd2FfZ3c+xAQMKeP5WM4b3aad8cum9y9QLZ1E=

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ cosmoz-behaviors
 =================
 
 [![Build Status](https://travis-ci.org/Neovici/cosmoz-behaviors.svg?branch=master)](https://travis-ci.org/Neovici/cosmoz-behaviors)
+[![Sauce Test Status](https://saucelabs.com/buildstatus/nomego)](https://saucelabs.com/u/nomego)
 [![Published on webcomponents.org](https://img.shields.io/badge/webcomponents.org-published-blue.svg)](https://www.webcomponents.org/element/Neovici/cosmoz-behaviors)
 
 ## &lt;cosmoz-behaviors&gt;
@@ -9,3 +10,9 @@ cosmoz-behaviors
 **cosmoz-behaviors** is a set of behaviors containing date, money and template
 management functionality commonly needed in page views. This component does
 not contain any visual element.
+
+### Big Thanks
+
+Cross-browser Testing Platform and Open Source <3 Provided by [Sauce Labs][sauce_homepage]
+
+[sauce_homepage]: https://saucelabs.com

--- a/README.md
+++ b/README.md
@@ -15,4 +15,6 @@ not contain any visual element.
 
 Cross-browser Testing Platform and Open Source <3 Provided by [Sauce Labs][sauce_homepage]
 
+[![Sauce Test Status](https://saucelabs.com/browser-matrix/nomego.svg)](https://saucelabs.com/u/nomego)
+
 [sauce_homepage]: https://saucelabs.com

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,11 +1,17 @@
 {
 	"plugins": {
 		"local": {
-			"browsers": ["chrome", "firefox"]
+			"browsers": [
+				"chrome",
+				"firefox"
+			]
 		},
 		"istanbul": {
 			"dir": "./coverage",
-			"reporters": ["text-summary", "lcov"],
+			"reporters": [
+				"text-summary",
+				"lcov"
+			],
 			"include": [
 				"cosmoz-behaviors.html",
 				"cosmoz-datehelper-behavior.html",
@@ -13,6 +19,25 @@
 				"cosmoz-templatehelper-behavior.html"
 			],
 			"exclude": []
+		},
+		"sauce": {
+			"browsers": [{
+				"browserName": "microsoftedge",
+				"platform": "Windows 10",
+				"version": ""
+			}, {
+				"browserName": "chrome",
+				"platform": "Windows 10",
+				"version": "dev"
+			}, {
+				"browserName": "chrome",
+				"platform": "Windows 10",
+				"version": "beta"
+			}, {
+				"browserName": "safari",
+				"platform": "macOS 10.13",
+				"version": "11.1"
+			}]
 		}
 	}
 }


### PR DESCRIPTION
Added configuration for SauceLabs testing, account "nomego" - Open Sauce (5 concurrent sessions for all repos combined)

For that reason I left Firefox latest and Chrome stable testing on Travis and only added new setups (Chrome beta, Chrome dev, Edge and Safari) through Sauce Labs.

SAUCE_USERNAME is encrypted due to some hint in guides, but realize that it's exposed through the README.md anyway for badges and browser matrix.